### PR TITLE
mullvad launch on login

### DIFF
--- a/modules/home-manager/modules/display/compositor/hyprland/default.nix
+++ b/modules/home-manager/modules/display/compositor/hyprland/default.nix
@@ -393,7 +393,7 @@ in
               ${davinci}
               ${blueman}
               ${nm}
-              # ${torrent}
+              ${torrent}
               ${hypridle}
               ${hyprsunset}
             '';

--- a/modules/networking/torrent/default.nix
+++ b/modules/networking/torrent/default.nix
@@ -13,7 +13,6 @@ with lib; let
     "194.242.2.5#extended.dns.mullvad.net"
     "194.242.2.6#family.dns.mullvad.net"
     "194.242.2.9#all.dns.mullvad.net"
-    "194.242.2.9#all.dns.mullvad.net"
   ];
 in {
   options = {


### PR DESCRIPTION
- **fix(hyprland): breaking config changes**
- **chore(nix): add cardanix, update flake.lock**
- **fix(nix): pass inputs to crypto module**
- **chore(nix): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): update**
- **feat(nix): enable fetch-closure**
- **chore(chromium): install dictionaries**
- **feat(brave): add extensions**
- **chore(firefox): uninstall by default**
- **feat(brave): add more extensions**
- **chore(brave): remove deepl**
- **chore(brave): remove more exts**
- **feat(hyprland): add hyprlock, hypridle**
- **fix(lockscreen): default false**
- **fix(swaync): typo**
- **feat(hyprlock): config using catppuccin**
- **feat(hyprlock): update font, imgs**
- **fix(hyprlock): update style**
- **fix(sway-audio-idle-inhibit): use nixpkgs version**
- **fix(hyprlock): dont suspend with sound**
- **chore(hyprlock): retry config**
- **feat(hypridle): expose on path**
- **chore(hyprlock): update config**
- **chore(uwsm): first config**
- **fix(uwsm): typo**
- **test(displayManager): remove default session**
- **fix(uwsm): use exec**
- **fix(hyprland): no uwsm, use hypridle**
- **fix(hyprland): typo**
- **fix(hyprland): typo**
- **fix(hyprland): exit dispatch**
- **chore(hyprlock): update config**
- **feat(hyprsunset): add**
- **chore(shell): update shell profile**
- **feat(hyprland): enable hyprsunset by default**
- **fix(shell): add ld libs to shell**
- **chore(hyprland): browser spawn**
- **test(hyprland): mullvad not open on login**
- **feat(hyprlock): do not idle if deactiveated**
- **chore(mullvad): launch app on login**
