### PR TITLE
chore(nix): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -461,11 +461,11 @@
         "nixpkgs": "nixpkgs_15"
       },
       "locked": {
-        "lastModified": 1732106666,
-        "narHash": "sha256-leZVIGzfNZussDMma+Mu6TNaahWTWl0kWqR4xJdQL+w=",
+        "lastModified": 1732109288,
+        "narHash": "sha256-eKipUFZvw8w55QkCPQAQmysRsXRUhZPFgJqWdtESV8c=",
         "owner": "clemenscodes",
         "repo": "cardanix",
-        "rev": "2106aa891d956c8a372a0ae5be3373e9f7b35edb",
+        "rev": "29bd52265892c4a25884065aa2e126acbc2d0e12",
         "type": "github"
       },
       "original": {
@@ -5367,11 +5367,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732103128,
-        "narHash": "sha256-ss6/TNvQgIHPxskSC5CrxuGEVWcq1g6Glh4mUqd01Ho=",
+        "lastModified": 1732106864,
+        "narHash": "sha256-5RWkCir5qDXRbWHQz83bgN0MHadFuReyfYPXUYcQeOs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "50c118bb8b06e1a6a643b21a8522051cec0ee6c7",
+        "rev": "a59251d9f044e153825700bdb65c1a5abd092600",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
- **fix(ncmpcpp): unbind seek command**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nix): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(fonts): decrease font size**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(android): disable modules**
- **chore(nix): update, add shortcut**
- **fix(nix): typo**
- **chore(opengl): update ld lib path**
- **chore(nix): update**
- **fix(catppuccin): accent typo**
- **fix(icon-theme): typo**
- **fix(catppuccin): typo**
- **fix(papirus): typo**
- **fix(kvantum): typo**
- **fix(kvantum): typo**
- **fix(kvantum): typo**
- **fix(kvantum): package**
- **test(kvantum): typo**
- **test(kvantum): typo**
- **chore(nix): update**
- **chore(nvim): update**
- **chore(nix): update**
- **chore(nix): update**
- **fix(amdgpu): rocm ocl icd**
- **chore(nvim): update**
- **chore(nvim): update**
- **fix(hyprland): breaking config changes**
- **chore(nix): add cardanix, update flake.lock**
- **fix(nix): pass inputs to crypto module**
- **chore(nix): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): update**
- **feat(nix): enable fetch-closure**
- **chore(chromium): install dictionaries**
- **feat(brave): add extensions**
- **chore(firefox): uninstall by default**
- **feat(brave): add more extensions**
- **chore(brave): remove deepl**
- **chore(brave): remove more exts**
- **feat(hyprland): add hyprlock, hypridle**
- **fix(lockscreen): default false**
- **fix(swaync): typo**
- **feat(hyprlock): config using catppuccin**
- **feat(hyprlock): update font, imgs**
- **fix(hyprlock): update style**
- **fix(sway-audio-idle-inhibit): use nixpkgs version**
- **fix(hyprlock): dont suspend with sound**
- **chore(hyprlock): retry config**
- **feat(hypridle): expose on path**
- **chore(hyprlock): update config**
- **chore(uwsm): first config**
- **fix(uwsm): typo**
- **test(displayManager): remove default session**
- **fix(uwsm): use exec**
- **fix(hyprland): no uwsm, use hypridle**
- **fix(hyprland): typo**
- **fix(hyprland): typo**
- **fix(hyprland): exit dispatch**
- **chore(hyprlock): update config**
- **feat(hyprsunset): add**
- **chore(shell): update shell profile**
- **feat(hyprland): enable hyprsunset by default**
- **fix(shell): add ld libs to shell**
- **chore(hyprland): browser spawn**
- **test(hyprland): mullvad not open on login**
- **feat(hyprlock): do not idle if deactiveated**
- **chore(mullvad): launch app on login**
- **feat(gaming): mangohud, add wine lutris closure**
- **fix(gamescope): typo**
- **fix(gamemode): nesting**
- **fix(steam): typo**
- **chore(fs): add exfat support**
- **feat(fs): add gparted**
- **chore(fs): use exfat-fuse**
- **feat(fs): install parted, xhost for gparted**
- **chore(amd): install vulkan-tools**
- **fix(lutris): add vulkan to closure**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): update**
- **feat(nix): update version**
- **test(nameservers): comment mullvad dns**
- **fix(nix): syntax**
- **test(networking): more mullvad dns**
- **chore(nix): update**
- **chore(nix): update**
