### PR TITLE
fix session vars

### DIFF
--- a/modules/home-manager/modules/shell/zsh/default.nix
+++ b/modules/home-manager/modules/shell/zsh/default.nix
@@ -48,16 +48,17 @@ in
         sessionVariables = {
           MOON = "${config.home.homeDirectory}/${flake}";
           FLAKE = "${config.home.homeDirectory}/${flake}/nix";
-          ANDROID_USER_HOME = "$XDG_DATA_HOME/android";
           NIXOS_OZONE_WL = 1;
+          XDG_DATA_HOME = ''''${$XDG_DATA_HOME:-$HOME/.local/share}'';
+          ANDROID_USER_HOME = "$XDG_DATA_HOME/android";
           CARGO_HOME = "$XDG_DATA_HOME/cargo";
-          JAVA_HOME = "/etc/profiles/per-user/${user}";
           GOPATH = "$XDG_DATA_HOME/go";
           MBSYNCRC = "$XDG_CONFIG_HOME/mbsync/config";
           M2_HOME = "$XDG_DATA_HOME/m2";
           CUDA_CACHE_PATH = "$XDG_CACHE_HOME/nv";
           WINEPREFIX = "$XDG_DATA_HOME/wine";
           LD_LIBRARY_PATH = "/run/opengl-driver/lib:$LD_LIBRARY_PATH";
+          JAVA_HOME = "/etc/profiles/per-user/${user}";
         };
       };
       programs = {


### PR DESCRIPTION
- **feat(gaming): mangohud, add wine lutris closure**
- **fix(gamescope): typo**
- **fix(gamemode): nesting**
- **fix(steam): typo**
- **chore(fs): add exfat support**
- **feat(fs): add gparted**
- **chore(fs): use exfat-fuse**
- **feat(fs): install parted, xhost for gparted**
- **chore(amd): install vulkan-tools**
- **fix(lutris): add vulkan to closure**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): update**
- **feat(nix): update version**
- **test(nameservers): comment mullvad dns**
- **fix(nix): syntax**
- **test(networking): more mullvad dns**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): update**
- **test(firewall): open ports used in flo logs**
- **fix(env): session vars**
