### PR TITLE
fix logoutlaunch lock

### DIFF
--- a/modules/home-manager/modules/display/launcher/rofi/logoutlaunch/default.nix
+++ b/modules/home-manager/modules/display/launcher/rofi/logoutlaunch/default.nix
@@ -71,7 +71,7 @@ pkgs.writeShellScriptBin "logoutlaunch" ''
     $shutdown) run_cmd --shutdown ;;
     $reboot) run_cmd --reboot ;;
     $hibernate) run_cmd --hibernate ;;
-    $lock) swaylock -f ;;
+    $lock) loginctl lock-session ;;
     $suspend) run_cmd --suspend ;;
     $logout) run_cmd --logout ;;
   esac


### PR DESCRIPTION
- **feat(gaming): mangohud, add wine lutris closure**
- **fix(gamescope): typo**
- **fix(gamemode): nesting**
- **fix(steam): typo**
- **chore(fs): add exfat support**
- **feat(fs): add gparted**
- **chore(fs): use exfat-fuse**
- **feat(fs): install parted, xhost for gparted**
- **chore(amd): install vulkan-tools**
- **fix(lutris): add vulkan to closure**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): update**
- **feat(nix): update version**
- **test(nameservers): comment mullvad dns**
- **fix(nix): syntax**
- **test(networking): more mullvad dns**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): update**
- **test(firewall): open ports used in flo logs**
- **fix(env): session vars**
- **chore(nvim): update**
- **chore(nix): update**
- **chore(nix): update**
- **fix(env): session vars**
- **feat(wine): update**
- **chore(gaming): update steam config**
- **fix(sddm): default session**
- **test(firewall): more ports**
- **fix(logout): lock session via gui**
