### PR TITLE
chore(nix): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -37,11 +37,11 @@
     "CHaP_3": {
       "flake": false,
       "locked": {
-        "lastModified": 1732639071,
-        "narHash": "sha256-XY+LlzuumeRovfBMXIPS90Trk7HTxpUMFFdL4bmMZDU=",
+        "lastModified": 1730295876,
+        "narHash": "sha256-ijnHTQ6eKIQ9FpEqDKt6c7vuFYN8aOBDhonp67utx2s=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "6df7fca74cc3a34babfa7ce7cb4b7a8c72c70982",
+        "rev": "25591f43ab943d5a070db5e8a2b9ff3a499d4d92",
         "type": "github"
       },
       "original": {
@@ -665,11 +665,11 @@
         "nixpkgs": "nixpkgs_17"
       },
       "locked": {
-        "lastModified": 1733074900,
-        "narHash": "sha256-wzViIQJb1O+azantorYjkqb7OE9yB3m24iNMepkILRc=",
+        "lastModified": 1733150367,
+        "narHash": "sha256-7HXyghQUNQD5SpbsqR5cRCABucTXrvKArzGHs/P9aoY=",
         "owner": "clemenscodes",
         "repo": "cardanix",
-        "rev": "70632ab4834077f144290723f4223b307d6c6ba7",
+        "rev": "a6bd2f6ec372d4e10f3d58d2058837e8195272f7",
         "type": "github"
       },
       "original": {
@@ -867,16 +867,16 @@
         "utils": "utils_3"
       },
       "locked": {
-        "lastModified": 1732705838,
-        "narHash": "sha256-v0q8qHdI6LKc8mP43QZt3UGdTNDQXE0aF6QapvZsTvU=",
-        "owner": "IntersectMBO",
+        "lastModified": 1733150079,
+        "narHash": "sha256-e8xNDfTmJJpqJcqZEOq+99KhyLS8TXJmDYzflnx7xzo=",
+        "owner": "clemenscodes",
         "repo": "cardano-node",
-        "rev": "36871ba0cd3e86a5dbcfd6878cdb7168bb4e56a1",
+        "rev": "48916fd0bf440245149e7ca81ce6b42f53d89a93",
         "type": "github"
       },
       "original": {
-        "owner": "IntersectMBO",
-        "ref": "10.1.3",
+        "owner": "clemenscodes",
+        "ref": "feature/custom-state-dir",
         "repo": "cardano-node",
         "type": "github"
       }
@@ -4505,11 +4505,11 @@
         "sodium": "sodium_3"
       },
       "locked": {
-        "lastModified": 1728687575,
-        "narHash": "sha256-38uD8SqT557eh5yyRYuthKm1yTtiWzAN0FH7L/01QKM=",
+        "lastModified": 1732287300,
+        "narHash": "sha256-lURsE6HdJX0alscWhbzCWyLRK8GpAgKuXeIgX31Kfqg=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "86c2bd46e8a08f62ea38ffe77cb4e9c337b42217",
+        "rev": "262cb2aec2ddd914124bab90b06fe24a1a74d02c",
         "type": "github"
       },
       "original": {
@@ -6350,11 +6350,11 @@
     },
     "nixpkgs_17": {
       "locked": {
-        "lastModified": 1732837521,
-        "narHash": "sha256-jNRNr49UiuIwaarqijgdTR2qLPifxsVhlJrKzQ8XUIE=",
+        "lastModified": 1733015953,
+        "narHash": "sha256-t4BBVpwG9B4hLgc6GUBuj3cjU7lP/PJfpTHuSqE+crk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "970e93b9f82e2a0f3675757eb0bfc73297cc6370",
+        "rev": "ac35b104800bff9028425fec3b6e8a41de2bbfff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
- **fix(ncmpcpp): unbind seek command**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nix): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(fonts): decrease font size**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(android): disable modules**
- **chore(nix): update, add shortcut**
- **fix(nix): typo**
- **chore(opengl): update ld lib path**
- **chore(nix): update**
- **fix(catppuccin): accent typo**
- **fix(icon-theme): typo**
- **fix(catppuccin): typo**
- **fix(papirus): typo**
- **fix(kvantum): typo**
- **fix(kvantum): typo**
- **fix(kvantum): typo**
- **fix(kvantum): package**
- **test(kvantum): typo**
- **test(kvantum): typo**
- **chore(nix): update**
- **chore(nvim): update**
- **chore(nix): update**
- **chore(nix): update**
- **fix(amdgpu): rocm ocl icd**
- **chore(nvim): update**
- **chore(nvim): update**
- **fix(hyprland): breaking config changes**
- **chore(nix): add cardanix, update flake.lock**
- **fix(nix): pass inputs to crypto module**
- **chore(nix): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): update**
- **feat(nix): enable fetch-closure**
- **chore(chromium): install dictionaries**
- **feat(brave): add extensions**
- **chore(firefox): uninstall by default**
- **feat(brave): add more extensions**
- **chore(brave): remove deepl**
- **chore(brave): remove more exts**
- **feat(hyprland): add hyprlock, hypridle**
- **fix(lockscreen): default false**
- **fix(swaync): typo**
- **feat(hyprlock): config using catppuccin**
- **feat(hyprlock): update font, imgs**
- **fix(hyprlock): update style**
- **fix(sway-audio-idle-inhibit): use nixpkgs version**
- **fix(hyprlock): dont suspend with sound**
- **chore(hyprlock): retry config**
- **feat(hypridle): expose on path**
- **chore(hyprlock): update config**
- **chore(uwsm): first config**
- **fix(uwsm): typo**
- **test(displayManager): remove default session**
- **fix(uwsm): use exec**
- **fix(hyprland): no uwsm, use hypridle**
- **fix(hyprland): typo**
- **fix(hyprland): typo**
- **fix(hyprland): exit dispatch**
- **chore(hyprlock): update config**
- **feat(hyprsunset): add**
- **chore(shell): update shell profile**
- **feat(hyprland): enable hyprsunset by default**
- **fix(shell): add ld libs to shell**
- **chore(hyprland): browser spawn**
- **test(hyprland): mullvad not open on login**
- **feat(hyprlock): do not idle if deactiveated**
- **chore(mullvad): launch app on login**
- **feat(gaming): mangohud, add wine lutris closure**
- **fix(gamescope): typo**
- **fix(gamemode): nesting**
- **fix(steam): typo**
- **chore(fs): add exfat support**
- **feat(fs): add gparted**
- **chore(fs): use exfat-fuse**
- **feat(fs): install parted, xhost for gparted**
- **chore(amd): install vulkan-tools**
- **fix(lutris): add vulkan to closure**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): update**
- **feat(nix): update version**
- **test(nameservers): comment mullvad dns**
- **fix(nix): syntax**
- **test(networking): more mullvad dns**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): update**
- **test(firewall): open ports used in flo logs**
- **fix(env): session vars**
- **chore(nvim): update**
- **chore(nix): update**
- **chore(nix): update**
- **fix(env): session vars**
- **feat(wine): update**
- **chore(gaming): update steam config**
- **fix(sddm): default session**
- **test(firewall): more ports**
- **fix(logout): lock session via gui**
- **feat(fuse): allow other**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): udpate**
- **chore(networking): nftables**
- **chore(kernel): remove rust patch**
- **feat(git): difftastic**
- **feat(dns): add option for mullvad dns**
- **fix(dns): add dns module**
- **feat(gaming): add umu**
- **feat(brave): add zotero connector extension**
- **chore(nix): update**
- **chore(cardanix): update**
- **fix(dev): remove cardano module, use cardanix**
- **fix(pkgs): nerd-fonts, update**
- **fix(gtk): font**
- **chore(cardanix): update**
- **chore(cardanix): update**
- **chore(cardanix): update**
- **chore(cardanix): update**
