### PR TITLE
chore(nix): update

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -113,7 +113,7 @@
         inherit (inputs) nixpkgs;
         pkgs = import nixpkgs {
           inherit system;
-          overlays = [inputs.cardanix.overlays.${system}];
+          overlays = [] ++ inputs.cardanix.overlays.${system};
         };
       in {
         nixosModules = {


### PR DESCRIPTION
- **fix(ncmpcpp): unbind seek command**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nix): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(fonts): decrease font size**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(android): disable modules**
- **chore(nix): update, add shortcut**
- **fix(nix): typo**
- **chore(opengl): update ld lib path**
- **chore(nix): update**
- **fix(catppuccin): accent typo**
- **fix(icon-theme): typo**
- **fix(catppuccin): typo**
- **fix(papirus): typo**
- **fix(kvantum): typo**
- **fix(kvantum): typo**
- **fix(kvantum): typo**
- **fix(kvantum): package**
- **test(kvantum): typo**
- **test(kvantum): typo**
- **chore(nix): update**
- **chore(nvim): update**
- **chore(nix): update**
- **chore(nix): update**
- **fix(amdgpu): rocm ocl icd**
- **chore(nvim): update**
- **chore(nvim): update**
- **fix(hyprland): breaking config changes**
- **chore(nix): add cardanix, update flake.lock**
- **fix(nix): pass inputs to crypto module**
- **chore(nix): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): update**
- **feat(nix): enable fetch-closure**
- **chore(chromium): install dictionaries**
- **feat(brave): add extensions**
- **chore(firefox): uninstall by default**
- **feat(brave): add more extensions**
- **chore(brave): remove deepl**
- **chore(brave): remove more exts**
- **feat(hyprland): add hyprlock, hypridle**
- **fix(lockscreen): default false**
- **fix(swaync): typo**
- **feat(hyprlock): config using catppuccin**
- **feat(hyprlock): update font, imgs**
- **fix(hyprlock): update style**
- **fix(sway-audio-idle-inhibit): use nixpkgs version**
- **fix(hyprlock): dont suspend with sound**
- **chore(hyprlock): retry config**
- **feat(hypridle): expose on path**
- **chore(hyprlock): update config**
- **chore(uwsm): first config**
- **fix(uwsm): typo**
- **test(displayManager): remove default session**
- **fix(uwsm): use exec**
- **fix(hyprland): no uwsm, use hypridle**
- **fix(hyprland): typo**
- **fix(hyprland): typo**
- **fix(hyprland): exit dispatch**
- **chore(hyprlock): update config**
- **feat(hyprsunset): add**
- **chore(shell): update shell profile**
- **feat(hyprland): enable hyprsunset by default**
- **fix(shell): add ld libs to shell**
- **chore(hyprland): browser spawn**
- **test(hyprland): mullvad not open on login**
- **feat(hyprlock): do not idle if deactiveated**
- **chore(mullvad): launch app on login**
- **feat(gaming): mangohud, add wine lutris closure**
- **fix(gamescope): typo**
- **fix(gamemode): nesting**
- **fix(steam): typo**
- **chore(fs): add exfat support**
- **feat(fs): add gparted**
- **chore(fs): use exfat-fuse**
- **feat(fs): install parted, xhost for gparted**
- **chore(amd): install vulkan-tools**
- **fix(lutris): add vulkan to closure**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): update**
- **feat(nix): update version**
- **test(nameservers): comment mullvad dns**
- **fix(nix): syntax**
- **test(networking): more mullvad dns**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): update**
- **test(firewall): open ports used in flo logs**
- **fix(env): session vars**
- **chore(nvim): update**
- **chore(nix): update**
- **chore(nix): update**
- **fix(env): session vars**
- **feat(wine): update**
- **chore(gaming): update steam config**
- **fix(sddm): default session**
- **test(firewall): more ports**
- **fix(logout): lock session via gui**
- **feat(fuse): allow other**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): udpate**
- **chore(networking): nftables**
- **chore(kernel): remove rust patch**
- **feat(git): difftastic**
- **feat(dns): add option for mullvad dns**
- **fix(dns): add dns module**
- **feat(gaming): add umu**
- **feat(brave): add zotero connector extension**
- **chore(nix): update**
- **chore(cardanix): update**
- **fix(dev): remove cardano module, use cardanix**
- **fix(pkgs): nerd-fonts, update**
- **fix(gtk): font**
- **chore(cardanix): update**
- **chore(cardanix): update**
- **chore(cardanix): update**
- **chore(cardanix): update**
- **chore(cardanix): update**
- **chore(cardanix): update**
- **chore(cardanix): update**
- **feat(cardano-node): use overlay cardano-node**
- **fix(nix): syntax**
