### PR TITLE
chore(nix): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -664,11 +664,11 @@
         "nixpkgs": "nixpkgs_17"
       },
       "locked": {
-        "lastModified": 1733156188,
-        "narHash": "sha256-DyHX8ct0l7KVUVdWQa3itMV2ZVMVucofAKUgfOMz9ac=",
+        "lastModified": 1733272435,
+        "narHash": "sha256-go0sd35AidrXvAXofJpbvN7qt9hufAMI2svt2qXHowo=",
         "owner": "clemenscodes",
         "repo": "cardanix",
-        "rev": "fa4f3a152e25e5f3f5b5afb79d3124ddfaca5c15",
+        "rev": "2218f716c0d85eeba9ff8416a98b9a3a23ea829a",
         "type": "github"
       },
       "original": {
@@ -866,16 +866,15 @@
         "utils": "utils_3"
       },
       "locked": {
-        "lastModified": 1733152804,
-        "narHash": "sha256-PKURZ0WazZ7FMrn3DsZiy6PXTtV4oK8RseGROWaQ8bY=",
-        "owner": "clemenscodes",
+        "lastModified": 1733261293,
+        "narHash": "sha256-JaqXZDH//3a0RRCOpa6FpPdRhNV8qqcnej6hxyqTcEQ=",
+        "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "1bf5fa387a63741f30fee799c29cf0c188c983c1",
+        "rev": "16c4484243e074aab8850a10625ada86df7c1597",
         "type": "github"
       },
       "original": {
-        "owner": "clemenscodes",
-        "ref": "feature/custom-state-dir",
+        "owner": "IntersectMBO",
         "repo": "cardano-node",
         "type": "github"
       }

--- a/modules/crypto/cardanix/default.nix
+++ b/modules/crypto/cardanix/default.nix
@@ -1,46 +1,52 @@
-{inputs, pkgs, ...}: {
+{
+  inputs,
+  pkgs,
+  ...
+}: {
   config,
   lib,
   system,
   ...
-}: let
+}:
+with lib; let
   cfg = config.modules.crypto;
-in
-  with lib; {
-    options = {
-      modules = {
-        crypto = {
-          cardanix = {
-            enable = mkEnableOption "Enable cardanix" // {default = false;};
-          };
+in {
+  options = {
+    modules = {
+      crypto = {
+        cardanix = {
+          enable = mkEnableOption "Enable cardanix" // {default = false;};
         };
       };
     };
-    imports = [inputs.cardanix.nixosModules.${system}];
-
-    config = mkIf (cfg.enable && cfg.cardanix.enable) {
-      services = {
-        cardano-node = {
-          package = pkgs.cardano-node;
-        };
-      };
-      cardano = {
-        enable = true;
-        address = {
-          enable = true;
-        };
-        node = {
-          enable = true;
-        };
-        wallet = {
-          enable = true;
-        };
-        db-sync = {
-          enable = true;
-        };
-        daedalus = {
-          enable = true;
-        };
+  };
+  imports = [
+    inputs.cardanix.nixosModules.${system}
+  ];
+  config = mkIf (cfg.enable && cfg.cardanix.enable) {
+    services = {
+      cardano-node = {
+        package = pkgs.cardano-node;
       };
     };
-  }
+    cardano = {
+      inherit (cfg.cardanix) enable;
+      address = {
+        inherit (cfg.cardanix) enable;
+      };
+      node = {
+        inherit (cfg.cardanix) enable;
+        port = 3001;
+      };
+      wallet = {
+        inherit (cfg.cardanix) enable;
+      };
+      db-sync = {
+        inherit (cfg.cardanix) enable;
+      };
+      daedalus = {
+        inherit (cfg.cardanix) enable;
+      };
+    };
+  };
+}


### PR DESCRIPTION
- **fix(ncmpcpp): unbind seek command**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nix): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(fonts): decrease font size**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(android): disable modules**
- **chore(nix): update, add shortcut**
- **fix(nix): typo**
- **chore(opengl): update ld lib path**
- **chore(nix): update**
- **fix(catppuccin): accent typo**
- **fix(icon-theme): typo**
- **fix(catppuccin): typo**
- **fix(papirus): typo**
- **fix(kvantum): typo**
- **fix(kvantum): typo**
- **fix(kvantum): typo**
- **fix(kvantum): package**
- **test(kvantum): typo**
- **test(kvantum): typo**
- **chore(nix): update**
- **chore(nvim): update**
- **chore(nix): update**
- **chore(nix): update**
- **fix(amdgpu): rocm ocl icd**
- **chore(nvim): update**
- **chore(nvim): update**
- **fix(hyprland): breaking config changes**
- **chore(nix): add cardanix, update flake.lock**
- **fix(nix): pass inputs to crypto module**
- **chore(nix): update**
- **chore(nvim): update**
- **chore(nvim): update**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): update**
- **feat(nix): enable fetch-closure**
- **chore(chromium): install dictionaries**
- **feat(brave): add extensions**
- **chore(firefox): uninstall by default**
- **feat(brave): add more extensions**
- **chore(brave): remove deepl**
- **chore(brave): remove more exts**
- **feat(hyprland): add hyprlock, hypridle**
- **fix(lockscreen): default false**
- **fix(swaync): typo**
- **feat(hyprlock): config using catppuccin**
- **feat(hyprlock): update font, imgs**
- **fix(hyprlock): update style**
- **fix(sway-audio-idle-inhibit): use nixpkgs version**
- **fix(hyprlock): dont suspend with sound**
- **chore(hyprlock): retry config**
- **feat(hypridle): expose on path**
- **chore(hyprlock): update config**
- **chore(uwsm): first config**
- **fix(uwsm): typo**
- **test(displayManager): remove default session**
- **fix(uwsm): use exec**
- **fix(hyprland): no uwsm, use hypridle**
- **fix(hyprland): typo**
- **fix(hyprland): typo**
- **fix(hyprland): exit dispatch**
- **chore(hyprlock): update config**
- **feat(hyprsunset): add**
- **chore(shell): update shell profile**
- **feat(hyprland): enable hyprsunset by default**
- **fix(shell): add ld libs to shell**
- **chore(hyprland): browser spawn**
- **test(hyprland): mullvad not open on login**
- **feat(hyprlock): do not idle if deactiveated**
- **chore(mullvad): launch app on login**
- **feat(gaming): mangohud, add wine lutris closure**
- **fix(gamescope): typo**
- **fix(gamemode): nesting**
- **fix(steam): typo**
- **chore(fs): add exfat support**
- **feat(fs): add gparted**
- **chore(fs): use exfat-fuse**
- **feat(fs): install parted, xhost for gparted**
- **chore(amd): install vulkan-tools**
- **fix(lutris): add vulkan to closure**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): update**
- **feat(nix): update version**
- **test(nameservers): comment mullvad dns**
- **fix(nix): syntax**
- **test(networking): more mullvad dns**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): update**
- **test(firewall): open ports used in flo logs**
- **fix(env): session vars**
- **chore(nvim): update**
- **chore(nix): update**
- **chore(nix): update**
- **fix(env): session vars**
- **feat(wine): update**
- **chore(gaming): update steam config**
- **fix(sddm): default session**
- **test(firewall): more ports**
- **fix(logout): lock session via gui**
- **feat(fuse): allow other**
- **chore(nix): update**
- **chore(nix): update**
- **chore(nix): udpate**
- **chore(networking): nftables**
- **chore(kernel): remove rust patch**
- **feat(git): difftastic**
- **feat(dns): add option for mullvad dns**
- **fix(dns): add dns module**
- **feat(gaming): add umu**
- **feat(brave): add zotero connector extension**
- **chore(nix): update**
- **chore(cardanix): update**
- **fix(dev): remove cardano module, use cardanix**
- **fix(pkgs): nerd-fonts, update**
- **fix(gtk): font**
- **chore(cardanix): update**
- **chore(cardanix): update**
- **chore(cardanix): update**
- **chore(cardanix): update**
- **chore(cardanix): update**
- **chore(cardanix): update**
- **chore(cardanix): update**
- **feat(cardano-node): use overlay cardano-node**
- **fix(nix): syntax**
- **fix(nix): syntax**
- **fix(nix): syntax**
- **chore(cardanix): update**
- **chore(cardanix): update**
